### PR TITLE
Added System.Runtime to References

### DIFF
--- a/src/CoiniumServ/CoiniumServ.csproj
+++ b/src/CoiniumServ/CoiniumServ.csproj
@@ -106,6 +106,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Runtime, Version=4.0.0.0, Culture=neutral,    PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\build\packages\Microsoft.AspNet.Razor.3.2.0\lib\net45\System.Web.Razor.dll</HintPath>


### PR DESCRIPTION
Lack of System.Runtime caused compilation failures on Ubuntu 12.04 and 13.04 - Not sure about 14
