### PR TITLE
Fixed issue with Mpos database

### DIFF
--- a/src/CoiniumServ/Persistance/Layers/Mpos/MposStorage.Accounts.cs
+++ b/src/CoiniumServ/Persistance/Layers/Mpos/MposStorage.Accounts.cs
@@ -54,7 +54,7 @@ namespace CoiniumServ.Persistance.Layers.Mpos
                 {
                     return connection.Query<Account>(
                         @"SELECT a.id, w.username, a.coin_address as address FROM pool_worker as w
-                            INNER JOIN accounts as a ON a.id=w.account_id
+                            INNER JOIN coin_addresses as a ON a.id=w.account_id
                             WHERE w.username = @username",
                         new {username}).Single();
                 }


### PR DESCRIPTION
Since https://github.com/MPOS/php-mpos/commit/5240e37ccf760e7e339be070eff333cbb3df7f81, the field coin_address can not be found in the accounts table anymore. This PR should fix the issue, getting the coin_address out of the coin_adresses table and should close #795 and #741.