### PR TITLE
Make the recipients pay the transaction fee.

### DIFF
--- a/src/CoiniumServ/Daemon/DaemonClient.cs
+++ b/src/CoiniumServ/Daemon/DaemonClient.cs
@@ -684,7 +684,7 @@ namespace CoiniumServ.Daemon
         }
 
         /// <summary>
-        /// Send bitcoins to multiple addresses in one transaction. 
+        /// Send bitcoins to multiple addresses in one transaction and the recipients pay the transaction fee.
         /// Amounts are double-precision floating point numbers.
         /// </summary>
         /// <param name="fromAccount">The account to send the bitcoins from.</param>
@@ -694,7 +694,7 @@ namespace CoiniumServ.Daemon
         /// <returns>The transaction ID if succesful.</returns>
         public string SendMany(string fromAccount, Dictionary<string, decimal> toBitcoinAddress, int minConf = 1, string comment = "")
         {
-            return MakeRequest<string>("sendmany", fromAccount, toBitcoinAddress, minConf, comment);
+            return MakeRequest<string>("sendmany", fromAccount, toBitcoinAddress, minConf, comment, toBitcoinAddress.Keys);
         }
 
         /// <summary>


### PR DESCRIPTION
Distributes the transaction fee among the recipients instead of paying it out of the pool's funds.

The change adds a fifth parameter to the `sendmany` command, with the addresses of the recipients, and is known to work for BTC, LTC and SUSU.

It may help with issues #547 and #866 but I have not confirmed it.

Gratuity not required, but very much appreciated:
BTC: qqlv8uma99jjsgh5pvx30fcrv3jkyl6z7ctldf7ugu
LTC: MKTLj9P9FjSTtVtKJ9gGnkU2BgVRBUBy96
SUSU: SST9WMpGAEEoRk4rAM7X4UJ91RgKitbVeu